### PR TITLE
feat: keep incoming deleted messages visible locally

### DIFF
--- a/Telegram/SourceFiles/data/data_session.cpp
+++ b/Telegram/SourceFiles/data/data_session.cpp
@@ -2892,6 +2892,9 @@ void Session::processMessagesDeleted(
 	for (const auto &messageId : data) {
 		const auto i = list ? list->find(messageId.v) : Messages::iterator();
 		if (list && i != list->end()) {
+			if (!i->second->out()) {
+				continue;
+			}
 			const auto history = i->second->history();
 			i->second->destroy();
 			if (!history->chatListMessageKnown()) {
@@ -2910,6 +2913,9 @@ void Session::processNonChannelMessagesDeleted(const QVector<MTPint> &data) {
 	auto historiesToCheck = base::flat_set<not_null<History*>>();
 	for (const auto &messageId : data) {
 		if (const auto item = nonChannelMessage(messageId.v)) {
+			if (!item->out()) {
+				continue;
+			}
 			const auto history = item->history();
 			item->destroy();
 			if (!history->chatListMessageKnown()) {


### PR DESCRIPTION
## Summary
- Messages deleted by other users no longer disappear from the local message list
- Only outgoing messages (sent by the local user) are removed when a delete event is received
- Incoming messages from other users survive deletion updates and remain visible

## Implementation
Modified `processMessagesDeleted()` and `processNonChannelMessagesDeleted()` in `data_session.cpp` to skip `destroy()` for any message where `item->out()` returns false.

## Test plan
- [ ] Have another user delete a message in a shared chat — confirm it stays visible on your end
- [ ] Delete one of your own messages — confirm it still disappears normally
- [ ] Test in both regular chats and channels

🤖 Generated with [Claude Code](https://claude.com/claude-code)