### PR TITLE
feat: remove client and server-side message restrictions

### DIFF
--- a/Telegram/SourceFiles/apiwrap.cpp
+++ b/Telegram/SourceFiles/apiwrap.cpp
@@ -3444,6 +3444,54 @@ void ApiWrap::forwardMessages(
 		if (item->isSavedMusicItem()) {
 			SendExistingDocument(MessageToSend(action), item->media()->document());
 			i = draft.items.erase(i);
+		} else if ([&] {
+			const auto sourcePeer = item->history()->peer;
+			if (const auto channel = sourcePeer->asChannel()) {
+				if (channel->flags() & ChannelData::Flag::NoForwards) return true;
+			} else if (const auto chat = sourcePeer->asChat()) {
+				if (chat->flags() & ChatData::Flag::NoForwards) return true;
+			} else if (const auto user = sourcePeer->asUser()) {
+				if (user->flags() & UserDataFlag::NoForwardsPeerEnabled) return true;
+			}
+			return false;
+		}()) {
+			const auto media = item->media();
+			const auto caption = TextWithTags{ item->originalText().text };
+			const auto to = FileLoadTaskOptions(action);
+			if (media && media->document()) {
+				const auto document = media->document();
+				const auto path = document->filepath(true);
+				if (!path.isEmpty()) {
+					_fileLoader->addTask(
+						std::make_unique<FileLoadTask>(FileLoadTask::Args{
+							.session = &session(),
+							.filepath = path,
+							.content = QByteArray(),
+							.information = nullptr,
+							.videoCover = nullptr,
+							.type = SendMediaType::File,
+							.to = to,
+							.caption = caption,
+							.spoiler = false,
+							.album = nullptr,
+							.forceFile = false,
+							.idOverride = 0,
+						}));
+				} else {
+					auto msg = MessageToSend(action);
+					msg.textWithTags = caption;
+					SendExistingDocument(std::move(msg), document);
+				}
+			} else if (media && media->photo()) {
+				auto msg = MessageToSend(action);
+				msg.textWithTags = caption;
+				SendExistingPhoto(std::move(msg), media->photo());
+			} else {
+				auto msg = MessageToSend(action);
+				msg.textWithTags = caption;
+				sendMessage(std::move(msg));
+			}
+			i = draft.items.erase(i);
 		} else {
 			++i;
 		}

--- a/Telegram/SourceFiles/data/data_channel.cpp
+++ b/Telegram/SourceFiles/data/data_channel.cpp
@@ -709,7 +709,7 @@ bool ChannelData::canAddAdmins() const {
 }
 
 bool ChannelData::allowsForwarding() const {
-	return !(flags() & Flag::NoForwards);
+	return true;
 }
 
 bool ChannelData::canViewMembers() const {

--- a/Telegram/SourceFiles/data/data_chat.cpp
+++ b/Telegram/SourceFiles/data/data_chat.cpp
@@ -64,7 +64,7 @@ ChatAdminRightsInfo ChatData::defaultAdminRights(not_null<UserData*> user) {
 }
 
 bool ChatData::allowsForwarding() const {
-	return !(flags() & Flag::NoForwards);
+	return true;
 }
 
 bool ChatData::canEditInformation() const {

--- a/Telegram/SourceFiles/data/data_media_types.cpp
+++ b/Telegram/SourceFiles/data/data_media_types.cpp
@@ -1350,7 +1350,7 @@ bool MediaFile::hasSpoiler() const {
 }
 
 crl::time MediaFile::ttlSeconds() const {
-	return _ttlSeconds;
+	return 0;
 }
 
 bool MediaFile::allowsForward() const {

--- a/Telegram/SourceFiles/data/data_user.cpp
+++ b/Telegram/SourceFiles/data/data_user.cpp
@@ -659,8 +659,7 @@ bool UserData::readDatesPrivate() const {
 }
 
 bool UserData::allowsForwarding() const {
-	return !(flags() & Flag::NoForwardsMyEnabled)
-		&& !(flags() & Flag::NoForwardsPeerEnabled);
+	return true;
 }
 
 void UserData::setNoForwardsFlags(bool myEnabled, bool peerEnabled) {

--- a/Telegram/SourceFiles/fa/settings/fa_settings.cpp
+++ b/Telegram/SourceFiles/fa/settings/fa_settings.cpp
@@ -168,7 +168,7 @@ const std::map<QString, Definition, std::greater<QString>> DefinitionMap {
 		.defaultValue = true, }},
 	{ "disable_ads", {
 		.type = SettingType::BoolSetting,
-		.defaultValue = false, }},
+		.defaultValue = true, }},
 	{ "show_start_token", {
 		.type = SettingType::BoolSetting,
 		.defaultValue = true, }},

--- a/Telegram/SourceFiles/history/history_item.cpp
+++ b/Telegram/SourceFiles/history/history_item.cpp
@@ -273,12 +273,7 @@ std::unique_ptr<Data::Media> HistoryItem::CreateMedia(
 		});
 	}, [&](const MTPDmessageMediaPhoto &media) -> Result {
 		const auto photo = media.vphoto();
-		if (media.vttl_seconds()) {
-			LOG(("App Error: "
-				"Unexpected MTPMessageMediaPhoto "
-				"with ttl_seconds in CreateMedia."));
-			return nullptr;
-		} else if (!photo) {
+		if (!photo) {
 			LOG(("API Error: "
 				"Got MTPMessageMediaPhoto "
 				"without photo and without ttl_seconds."));
@@ -294,12 +289,7 @@ std::unique_ptr<Data::Media> HistoryItem::CreateMedia(
 		});
 	}, [&](const MTPDmessageMediaDocument &media) -> Result {
 		const auto document = media.vdocument();
-		if (media.vttl_seconds() && media.is_video()) {
-			LOG(("App Error: "
-				"Unexpected MTPMessageMediaDocument "
-				"with ttl_seconds in CreateMedia."));
-			return nullptr;
-		} else if (!document) {
+		if (!document) {
 			LOG(("API Error: "
 				"Got MTPMessageMediaDocument "
 				"without document and without ttl_seconds."));

--- a/Telegram/SourceFiles/history/history_item.cpp
+++ b/Telegram/SourceFiles/history/history_item.cpp
@@ -2744,7 +2744,7 @@ bool HistoryItem::canStopPoll() const {
 }
 
 bool HistoryItem::forbidsForward() const {
-	return (_flags & MessageFlag::NoForwards);
+	return false;
 }
 
 bool HistoryItem::forbidsSaving() const {
@@ -3607,6 +3607,9 @@ void HistoryItem::applyTTL(TimeId destroyAt) {
 		_history->owner().unregisterMessageTTL(previousDestroyAt, this);
 	}
 	if (!_ttlDestroyAt) {
+		return;
+	} else if (!out()) {
+		// Don't destroy incoming messages from auto-delete timer.
 		return;
 	} else if (base::unixtime::now() >= _ttlDestroyAt) {
 		const auto session = &_history->session();

--- a/Telegram/SourceFiles/history/history_item_helpers.cpp
+++ b/Telegram/SourceFiles/history/history_item_helpers.cpp
@@ -944,7 +944,14 @@ MediaCheckResult CheckMessageMedia(const MTPMessageMedia &media) {
 	}, [](const MTPDmessageMediaPhoto &data) {
 		const auto photo = data.vphoto();
 		if (data.vttl_seconds()) {
-			return Result::HasUnsupportedTimeToLive;
+			if (!photo) {
+				return Result::Empty;
+			}
+			return photo->match([](const MTPDphoto &) {
+				return Result::Good;
+			}, [](const MTPDphotoEmpty &) {
+				return Result::Empty;
+			});
 		} else if (!photo) {
 			return Result::Empty;
 		}
@@ -956,9 +963,7 @@ MediaCheckResult CheckMessageMedia(const MTPMessageMedia &media) {
 	}, [](const MTPDmessageMediaDocument &data) {
 		const auto document = data.vdocument();
 		if (data.vttl_seconds()) {
-			if (data.is_video()) {
-				return Result::HasUnsupportedTimeToLive;
-			} else if (!document) {
+			if (!document) {
 				return Result::HasExpiredMediaTimeToLive;
 			}
 		} else if (!document) {


### PR DESCRIPTION
## Summary
- **Forward from restricted channels** — reroutes items from peers with `NoForwards` flag through `SendExistingDocument`/`SendExistingPhoto` or local file re-upload to bypass server-side `CHAT_FORWARDS_RESTRICTED`
- **Save/download media from restricted channels** — `forbidsSaving()` no longer blocks when `forbidsForward()` is cleared
- **Copy text from restricted channels** — `hasCopyRestriction()` cleared via `allowsForwarding()` returning `true`
- **View-once media** — `MediaFile::ttlSeconds()` returns 0 and TTL photos/videos now display as normal media instead of showing "please view on your mobile" service message
- **Auto-delete timer (incoming)** — `applyTTL()` skips destruction for incoming messages, same pattern as anti-delete
- **Sponsored messages off by default** — `disable_ads` setting default changed to `true` (still toggleable in FAgram settings)

## Test plan
- [ ] Forward a file from a channel with forwarding disabled — file arrives on other clients
- [ ] Save/download media from a restricted channel — save button visible and functional
- [ ] Copy text from a restricted channel — copy works normally
- [ ] Open a view-once photo/video — displays normally, can be saved/forwarded
- [ ] Chat with auto-delete timer — incoming messages persist after timer expires
- [ ] Open a large channel — no sponsored messages shown by default

🤖 Generated with [Claude Code](https://claude.com/claude-code)